### PR TITLE
Make content security policy allow Google fonts.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
           "tabs","activeTab","storage", "notifications"
         ],
 
-  "content_security_policy": "object-src 'self'"
+  "content_security_policy": "default-src 'self'; font-src https://fonts.gstatic.com; style-src https://fonts.googleapis.com"
 }


### PR DESCRIPTION
While trying to upload manually this extension to my chrome browser and not through the web store, I've encountered several errors which were fixed with these changes. With these changes, the extension can no be ported to firefox.